### PR TITLE
zapsyslog: include fields added using With() calls

### DIFF
--- a/zapsyslog/core.go
+++ b/zapsyslog/core.go
@@ -53,7 +53,7 @@ func (core *Core) Check(entry zapcore.Entry, checked *zapcore.CheckedEntry) *zap
 
 func (core *Core) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 	// Generate the message.
-	buffer, err := core.encoder.EncodeEntry(entry, fields)
+	buffer, err := core.encoder.EncodeEntry(entry, append(core.fields, fields...))
 	if err != nil {
 		return errors.Wrap(err, "failed to encode log entry")
 	}


### PR DESCRIPTION
When using the JSON encoder, fields added to the logger by calling `With()` were not included in the output wrote to syslog as they were not passed to `encoder.EncodeEntry()`.

This change includes fields added by calling `With()` in the output.

Before:
```
{
  "level": "info",
  "ts": 1508240108.2495,
  "msg": "struct test"
}
```

After:
```
{
  "level": "info",
  "ts": 1508240146.5777,
  "msg": "struct test",
  "value": {
    "Name": "test",
    "Value": 42
  }
}
```