### PR TITLE
Update sentry-go (0.5.1 -> 0.6.0)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/tchap/zapext/v2
 go 1.13
 
 require (
-	github.com/getsentry/sentry-go v0.5.1
+	github.com/getsentry/sentry-go v0.6.0
 	github.com/google/uuid v1.1.1
 	github.com/pkg/errors v0.9.1
 	go.uber.org/multierr v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga
 github.com/flosch/pongo2 v0.0.0-20190707114632-bbf5a6c351f4/go.mod h1:T9YF2M40nIgbVgp3rreNmTged+9HrbNTIQf1PsaIiTA=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
-github.com/getsentry/sentry-go v0.5.1 h1:MIPe7ScHADsrK2vznqmhksIUFxq7m0JfTh+ZIMkI+VQ=
-github.com/getsentry/sentry-go v0.5.1/go.mod h1:B8H7x8TYDPkeWPRzGpIiFO97LZP6rL8A3hEt8lUItMw=
+github.com/getsentry/sentry-go v0.6.0 h1:kPd+nr+dlXmaarUBg7xlC/qn+7wyMJL6PMsSn5fA+RM=
+github.com/getsentry/sentry-go v0.6.0/go.mod h1:0yZBuzSvbZwBnvaF9VwZIMen3kXscY8/uasKtAX1qG8=
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=

--- a/zapsentry/core.go
+++ b/zapsentry/core.go
@@ -135,7 +135,7 @@ func (core *Core) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 
 	// Process entry.
 	event.Level = zapLevelToSentrySeverity[entry.Level]
-	event.Timestamp = entry.Time.Unix()
+	event.Timestamp = entry.Time
 	event.Logger = entry.LoggerName
 
 	// Process fields.
@@ -248,9 +248,7 @@ func (core *Core) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 
 	// In case an HTTP request is present, add the HTTP interface.
 	if req != nil {
-		var request sentry.Request
-		request.FromHTTPRequest(req)
-		event.Request = request
+		event.Request = sentry.NewRequest(req)
 	}
 
 	// Add tags and extra into the packet.


### PR DESCRIPTION
Updating versions:
0.5.1: https://pkg.go.dev/github.com/getsentry/sentry-go@v0.5.1?tab=doc#Event
-> 
0.6.0: https://pkg.go.dev/github.com/getsentry/sentry-go@v0.6.0?tab=doc#Event

Adding Makefile for convenience :)