### PR TITLE
zapsentry: Make it possible to set Event.User object

### DIFF
--- a/zapsentry/core.go
+++ b/zapsentry/core.go
@@ -45,6 +45,7 @@ const (
 	ServerNameKey  = "server_name"
 	ErrorKey       = "error"
 	HTTPRequestKey = "http_request"
+	UserKey        = "user"
 )
 
 const ErrorStackTraceKey = "error_stack_trace"
@@ -182,6 +183,16 @@ func (core *Core) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 
 		case SkipKey:
 			return false
+
+		case UserKey:
+			switch user := field.Interface.(type) {
+			case User:
+				event.User = sentry.User(user)
+			case *User:
+				event.User = sentry.User(*user)
+			default:
+				field.AddTo(encoder)
+			}
 
 		default:
 			// Add to the encoder in case this is not a significant key.

--- a/zapsentry/user.go
+++ b/zapsentry/user.go
@@ -1,0 +1,33 @@
+package zapsentry
+
+import (
+	"github.com/getsentry/sentry-go"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// User extends sentry.User to be a zapcore.ObjectMarshaler.
+//
+// This object can be passed to the logger as a field,
+// causing the underlying core to set Event.User to the field value.
+type User sentry.User
+
+// MarshalLogObject implements zapcore.ObjectMarshaler interface.
+func (user User) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	add := func(key, value string) {
+		if value != "" {
+			enc.AddString(key, value)
+		}
+	}
+
+	add("email", user.Email)
+	add("id", user.ID)
+	add("ip_address", user.IPAddress)
+	add("username", user.Username)
+	return nil
+}
+
+// UserField turns the given user object into a field.
+func UserField(user User) zapcore.Field {
+	return zap.Object(UserKey, user)
+}


### PR DESCRIPTION
It is now possible to add a field using UserField helper
to set the user object on the underlying sentry.Event object.

This resolves #6 